### PR TITLE
Prefer "style" property when resolving

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ const {
 module.exports = (config = {}) => {
   const defaultConfig = {
     extensions: ['.css'],
+    mainFields: ['style', 'main'],
     modules: ['node_modules'],
     fileSystem: config.fileSystem
       ? null


### PR DESCRIPTION
The `style` field is a common way to designate a stylesheet in an npm package for bundlers. We should prefer this over the `main` field which in most cases points to Javascript.